### PR TITLE
Removed alternate privacy-policy path

### DIFF
--- a/front-end/content/privacy-policy/privacy.md
+++ b/front-end/content/privacy-policy/privacy.md
@@ -1,9 +1,0 @@
----
-path: /privacy
-title: Privacy Policy
-createPage: true
----
-
-# Privacy Policy
-
-some text goes here


### PR DESCRIPTION
Missed an existing privacy-policy folder with dummy content. Removing.
Privacy content lives in /privacy/privacy.md